### PR TITLE
Improve README and add example crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# navercafecrawler
+# NaverCafeCrawler
+
+This project provides a simple example for scraping articles from Naver Cafe using Python.
+
+## Requirements
+
+- Python 3.8 or later
+- Packages listed in `requirements.txt`
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the crawler with the cafe club ID and article ID:
+
+```bash
+python crawler.py <club_id> <article_id>
+```
+
+This will print the article title and content to standard output.
+
+**Note**: Only crawl content you are permitted to access and be sure to comply with Naver's terms of service.

--- a/crawler.py
+++ b/crawler.py
@@ -1,0 +1,51 @@
+import sys
+import requests
+from bs4 import BeautifulSoup
+
+
+def fetch_article(club_id: str, article_id: str) -> dict:
+    """Fetch an article from Naver Cafe using club_id and article_id.
+
+    Parameters
+    ----------
+    club_id : str
+        Naver Cafe club ID.
+    article_id : str
+        Article ID within the cafe.
+
+    Returns
+    -------
+    dict
+        A dictionary containing the article URL, title, and text content.
+    """
+    url = (
+        "https://cafe.naver.com/ArticleRead.nhn?"
+        f"clubid={club_id}&articleid={article_id}"
+    )
+    response = requests.get(url)
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    title_elem = soup.select_one("div.tit-box span.b")
+    content_elem = soup.select_one("#tbody")
+
+    return {
+        "url": url,
+        "title": title_elem.get_text(strip=True) if title_elem else "",
+        "content": content_elem.get_text(strip=True) if content_elem else "",
+    }
+
+
+def main(argv: list[str]) -> None:
+    if len(argv) != 3:
+        print("Usage: python crawler.py <club_id> <article_id>")
+        raise SystemExit(1)
+
+    club_id, article_id = argv[1], argv[2]
+    article = fetch_article(club_id, article_id)
+    print(article["title"])
+    print(article["content"])
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4


### PR DESCRIPTION
## Summary
- document project usage and installation steps
- add simple `crawler.py` example script
- specify Python dependencies in `requirements.txt`

## Testing
- `python -m py_compile crawler.py`
- `python crawler.py testclub testarticle` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68691a89a9c88326ada8580bd86c7f97